### PR TITLE
Not importing axum::routing::get, but only axum::routing - idiomatic.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-use axum::{routing::get, Router};
+use axum::{routing, Router};
 use std::env;
 
 #[tokio::main]
 async fn main() {
     // Build our application with a single route.
-    let app = Router::new().route("/", get(|| async { "Hello, Space!" }));
+    let app = Router::new().route("/", routing::get(|| async { "Hello, Space!" }));
     // Get the port to listen on from the environment, or default to 8080 if not present.
     let addr = format!(
         "127.0.0.1:{}",


### PR DESCRIPTION
Good to see Rust support on Deta. I'm diving in.

This change applies https://doc.rust-lang.org/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html#creating-idiomatic-use-paths (how it applies to functions).

Of course, it's likely that Axum examples/demos do have same non-idiomatic code
```rust
use axum::routing::get;
// ...
get(...);
```
But that is non-idiomatic nevertheless.